### PR TITLE
change data location

### DIFF
--- a/src/fiveoutofnine.sol
+++ b/src/fiveoutofnine.sol
@@ -80,7 +80,7 @@ contract fiveoutofnine is ERC721, Ownable, ReentrancyGuard {
         return fiveoutofnineART.getMetadata(tokenInternalIds[_tokenId], tokenMoves[_tokenId]);
     }
 
-    function setBaseURI(string memory _baseURI) external onlyOwner {
+    function setBaseURI(string calldata _baseURI) external onlyOwner {
         baseURI = _baseURI;
     }
 


### PR DESCRIPTION
for a function input parameter's data location, choosing <calldata> instead of <memory> costs less gas.