### PR TITLE
Fix import path for OpenZeppelin contracts in remappings

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,1 @@
-@openzeppelin/=lib/openzeppelin-contracts/contracts
+@openzeppelin/=lib/openzeppelin-contracts/contracts/

--- a/src/fiveoutofnine.sol
+++ b/src/fiveoutofnine.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/token/ERC721/ERC721.sol";
+import "@openzeppelin/access/Ownable.sol";
+import "@openzeppelin/utils/Strings.sol";
 
 import { Chess } from "./Chess.sol";
 import { Engine } from "./Engine.sol";

--- a/src/fiveoutofnineART.sol
+++ b/src/fiveoutofnineART.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/utils/Strings.sol";
 
 import { Chess } from "./Chess.sol";
 import { Base64 } from "./Base64.sol";


### PR DESCRIPTION
### Summary
This pull request addresses an issue with the import path for OpenZeppelin contracts in the remappings configuration. The original remapping was:
`@openzeppelin/=lib/openzeppelin-contracts/contracts`
This caused import statements like:
`import "@openzeppelin/contracts/utils/Strings.sol";`
to fail with a "file not found" error, as the `contracts` directory was already part of the remapping.

### Changes Made
- Updated the remapping to:
`@openzeppelin/=lib/openzeppelin-contracts/contracts/`
- Modified import statements to:
`import "@openzeppelin/utils/Strings.sol";
`
### Impact
These changes ensure that the import paths are correctly resolved, preventing file not found errors and improving the overall reliability of the project.

### Testing
- Verified that the new import paths work correctly by running the project and ensuring all dependencies are properly resolved.
- No additional tests were required as this change only affects the import paths.

### Additional Notes
If there are any further adjustments needed or additional tests required, please let me know. I'm happy to make any necessary changes.
